### PR TITLE
fix: macos version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Runner arch is included in the cache key.
+
+### Fixed
+
+- Fix runner os version resolution on macOS runners. (issue #24)
+
 ## [3.0.1] - 2024-03-08
 
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -77482,7 +77482,7 @@ async function getOsVersion() {
     const match = output.stdout.match(/VERSION_ID="(.*)"/);
     return match?.[1];
   }
-  if (runnerOs === "MacOS") {
+  if (runnerOs === "macOS") {
     const output = await exec.getExecOutput("sw_vers", ["-productVersion"], {
       silent: true
     });
@@ -77504,13 +77504,14 @@ async function getOsVersion() {
 }
 async function getCacheKey(input, version2) {
   const runnerOs = process.env.RUNNER_OS;
+  const runnerArch = process.env.RUNNER_ARCH;
   const jobId = process.env.GITHUB_JOB;
   const osVersion = await getOsVersion();
-  if (runnerOs === void 0 || jobId === void 0) {
-    core.setFailed("Could not determine runner OS or job ID");
+  if (runnerOs === void 0 || runnerArch === void 0 || jobId === void 0) {
+    core.setFailed("Could not determine runner OS, runner arch or job ID");
     process.exit(1);
   }
-  let hashKey = jobId + runnerOs + (osVersion ?? "");
+  let hashKey = jobId + runnerOs + runnerArch + (osVersion ?? "");
   hashKey += input.source.type;
   if (input.source.type === "registry") {
     hashKey += input.source.registry ?? "";

--- a/src/install.ts
+++ b/src/install.ts
@@ -50,7 +50,7 @@ async function getOsVersion(): Promise<string | undefined> {
     return match?.[1];
   }
 
-  if (runnerOs === 'MacOS') {
+  if (runnerOs === 'macOS') {
     const output = await exec.getExecOutput('sw_vers', ['-productVersion'], {
       silent: true,
     });
@@ -77,15 +77,20 @@ async function getCacheKey(
   version: ResolvedVersion,
 ): Promise<string> {
   const runnerOs = process.env.RUNNER_OS;
+  const runnerArch = process.env.RUNNER_ARCH;
   const jobId = process.env.GITHUB_JOB;
   const osVersion = await getOsVersion();
 
-  if (runnerOs === undefined || jobId === undefined) {
-    core.setFailed('Could not determine runner OS or job ID');
+  if (
+    runnerOs === undefined ||
+    runnerArch === undefined ||
+    jobId === undefined
+  ) {
+    core.setFailed('Could not determine runner OS, runner arch or job ID');
     process.exit(1);
   }
 
-  let hashKey = jobId + runnerOs + (osVersion ?? '');
+  let hashKey = jobId + runnerOs + runnerArch + (osVersion ?? '');
 
   hashKey += input.source.type;
   if (input.source.type === 'registry') {


### PR DESCRIPTION
- Fix macOS version detection (RUNNER_OS is `macOS`, not `MacOS`)
- Add the runner arch to the cache key.

Closes #24 