### PR TITLE
 feat: set CARGO_INSTALL_ROOT environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `CARGO_INSTALL_ROOT` environment variable is set when running `cargo install`.
+  This allows sub-processed using the `cargo install` command (such as
+  [yazi's build script](https://github.com/sxyazi/yazi/blob/c27ef58116794de7f559bca74e60e6e13ae92051/yazi-build/build.rs#L37))
+  to use the right installation path.
+
 ## [3.3.1] - 2025-06-17
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -67596,10 +67596,12 @@ async function getInstallSettings(input, version) {
   }
   const installPath = import_node_path.default.join(homePath, ".cargo-install", input.crate);
   const args = getInstallArgs(input, version, installPath);
+  const env2 = { CARGO_INSTALL_ROOT: installPath };
   const cacheKey = await getCacheKey(input, version, args);
   return {
     path: installPath,
     args,
+    env: env2,
     cacheKey
   };
 }
@@ -68246,7 +68248,8 @@ async function run() {
     core5.startGroup(
       `No cached version found, installing ${input.crate} using cargo...`
     );
-    await exec4.exec("cargo", install.args);
+    const env2 = { ...process.env, ...install.env };
+    await exec4.exec("cargo", install.args, { env: env2 });
     try {
       await cache.saveCache([install.path], install.cacheKey);
     } catch (error2) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,9 @@ async function run(): Promise<void> {
     core.startGroup(
       `No cached version found, installing ${input.crate} using cargo...`,
     );
-    await exec.exec('cargo', install.args);
+
+    const env = { ...process.env, ...install.env } as Record<string, string>;
+    await exec.exec('cargo', install.args, { env });
 
     try {
       await cache.saveCache([install.path], install.cacheKey);

--- a/src/install.ts
+++ b/src/install.ts
@@ -12,6 +12,7 @@ export type ResolvedVersion =
 export interface InstallSettings {
   path: string;
   args: string[];
+  env: Record<string, string>;
   cacheKey: string;
 }
 
@@ -29,11 +30,13 @@ export async function getInstallSettings(
 
   const installPath = path.join(homePath, '.cargo-install', input.crate);
   const args = getInstallArgs(input, version, installPath);
+  const env = { CARGO_INSTALL_ROOT: installPath };
   const cacheKey = await getCacheKey(input, version, args);
 
   return {
     path: installPath,
     args,
+    env,
     cacheKey,
   };
 }


### PR DESCRIPTION
Set the `CARGO_INSTALL_ROOT` environment variable so sub-processes runing `cargo install` will install in the right path (should fix https://github.com/baptiste0928/cargo-install/issues/34). 